### PR TITLE
Use :db instead of :store

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,18 @@ Our table suggests we have two SQL tables named "users" and "phones", each with 
                         :data data}})
 ```
 
-Finally, we need to add our component to the system map, including our datastore as a dependency:
+Finally, we need to add our component to the system map, including our datadb as a dependency:
 
 ```clojure
 (require '[fixtures.component :refer [fixtures]])
  
 (system-map
-  :store (...)
+  :db (...)
   :fixtures (c/using (fixtures (:fixtures config))
-              [:store]}))
+              [:db]}))
 ```
 
-**That's it!** Your done. Make sure your `fixtures` component is passed the datastore in the `:store` key. When you start your system, all your data should be bootstrapped into the database.
+**That's it!** Your done. Make sure your `fixtures` component is passed the datastore in the `:db` key. When you start your system, all your data should be bootstrapped into the database.
 
 #### Build Your Own Adapter
 
@@ -63,8 +63,8 @@ An adapter is no more than an implementation of the `fixtures.protocols.Loadable
 
 ```clojure
 (defprotocol Loadable
-  (load! [adapter store data])
-  (unload! [adapter store data]))
+  (load! [adapter db data])
+  (unload! [adapter db data]))
 ```
 
 Implement your own adapter with the two methods, and you're set:
@@ -72,12 +72,12 @@ Implement your own adapter with the two methods, and you're set:
 ```clojure
 (require '[fixtures.protocols :as p])
 
-(defrecord MyFavoriteDatastore
+(defrecord MyFavoriteDataStore
   fixtures.protocols.Loadable
-  (load! [adapter store data]
+  (load! [adapter db data]
     ...)
 
-  (unload! [adapter store data]
+  (unload! [adapter db data]
     ...))
 ```
 
@@ -87,16 +87,16 @@ See [here for a full example](https://github.com/banzai-inc/fixtures-component/b
 
 Leveraging an adapter is the preferred method for loading fixtures, however, if you're in a hurry, these two functions provide a quick and dirty way load your datastore.
 
-This method does one thing only – ensures setup and teardown is done in sync with the rest of the system. It's *totally* naive to *how* you load your fixtures. Whether you're loading a SQL, NoSQL, Postgres, or MySQL store, it's your responsibility to define setup and teardown procedures.
+This method does one thing only – ensures setup and teardown is done in sync with the rest of the system. It's *totally* naive to *how* you load your fixtures. Whether you're loading a SQL, NoSQL, Postgres, or MySQL db, it's your responsibility to define setup and teardown procedures.
 
 First, define two functions: `setup`, and `teardown`, each capable of receiving one argument representing your database:
 
 ```clojure
-(defn setup [store]
+(defn setup [db]
   (println "Setting up fixtures!")
   (comment "Do your thing: add records to your database using yesql, plain JDBC, whatever..."))
 
-(defn teardown [store]
+(defn teardown [db]
   (println "Tearing down fixtures")
   (comment "Delete your data"))
 ```
@@ -108,15 +108,15 @@ Add your `setup` and `teardown` functions to a config map, explicitly setting th
                         :teardown teardown}}
 ```
 
-Keep in mind, you cannot mix method #1 and #2, so don't declare `setup` and `adapter`, or `setup` and `data`. Declare your db component, and pass it as a dependency to the constructor function, `fixtures`, using the `store` key.
+Keep in mind, you cannot mix method #1 and #2, so don't declare `setup` and `adapter`, or `setup` and `data`. Declare your db component, and pass it as a dependency to the constructor function, `fixtures`, using the `db` key.
 
 ```clojure
 (require '[com.stuartsierra.component :as c])
 
 (c/system-map
-  :store (...)
+  :db (...)
   :fixtures (c/using (fixtures (:fixtures config)))
-              [:store])
+              [:db])
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Our table suggests we have two SQL tables named "users" and "phones", each with 
                         :data data}})
 ```
 
-Finally, we need to add our component to the system map, including our datadb as a dependency:
+Finally, we need to add our component to the system map, including our datastore as a dependency:
 
 ```clojure
 (require '[fixtures.component :refer [fixtures]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject fixtures-component "0.2.1"
+(defproject xzilend/fixtures-component "0.2.1"
   :description "Development fixtures component for the reloadable pattern"
   :url "https://github.com/banzai-inc/fixtures-component"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject xzilend/fixtures-component "0.2.1"
+(defproject fixtures-component "0.2.2"
   :description "Development fixtures component for the reloadable pattern"
   :url "https://github.com/banzai-inc/fixtures-component"
   :license {:name "Eclipse Public License"

--- a/src/fixtures/component.clj
+++ b/src/fixtures/component.clj
@@ -5,17 +5,17 @@
 (defrecord Fixtures [setup teardown adapter data]
   c/Lifecycle
   (start [component]
-    (let [store (:store component)]
+    (let [db (:db component)]
       (if adapter
-        (load! (adapter) store data)
-        (setup store)))
+        (load! (adapter) db data)
+        (setup db)))
     (assoc component :loaded true))
 
   (stop [component]
-    (let [store (:store component)]
+    (let [db (:db component)]
       (if adapter
-        (unload! (adapter) store data)
-        (teardown store)))
+        (unload! (adapter) db data)
+        (teardown db)))
     (assoc component :loaded false)))
 
 (defn fixtures
@@ -24,11 +24,11 @@
                 Required if setup/teardown are not provided.
                 Ignored if setup/teardown are provided.
     - data:     Data expected by the adapter.
-    - setup:    Setup function; receives one argument (store)
-    - teardown: Teardown function; receives one argument (store)
+    - setup:    Setup function; receives one argument (db)
+    - teardown: Teardown function; receives one argument (db)
 
     Example:
-    (fixtures {:setup (fn [store] (println \"Set up my db!\"))
+    (fixtures {:setup (fn [db] (println \"Set up my db!\"))
                :teardown ...})"
   [config]
   (map->Fixtures config))

--- a/src/fixtures/protocols.clj
+++ b/src/fixtures/protocols.clj
@@ -1,5 +1,5 @@
 (ns fixtures.protocols)
 
 (defprotocol Loadable
-  (load! [adapter store data])
-  (unload! [adapter store data]))
+  (load! [adapter db data])
+  (unload! [adapter db data]))

--- a/test/fixtures/adapters/jdbc_test.clj
+++ b/test/fixtures/adapters/jdbc_test.clj
@@ -5,7 +5,7 @@
             [fixtures.adapters.jdbc :refer [jdbc-adapter]]
             [clojure.java.jdbc :refer [query delete!]]))
 
-(def store {:spec (-> (user/load-config) :datastore :db-spec)})
+(def db {:spec (-> (user/load-config) :datastore :db-spec)})
 (def data [[:users [{:id 1} {:id 2}]]])
 (def error-data [[:non_existent_table [{:id 1}]]])
 
@@ -13,19 +13,19 @@
   (delete! spec :users []))
 
 (deftest load-test
-  (let [spec (:spec store)]
+  (let [spec (:spec db)]
     (clear spec)
-    (load! (jdbc-adapter) store data)
-    (= 2 (count (query (:spec store) ["select * from users"])))))
+    (load! (jdbc-adapter) db data)
+    (= 2 (count (query (:spec db) ["select * from users"])))))
 
 (deftest unload-test
-  (let [spec (:spec store)
+  (let [spec (:spec db)
         adapter (jdbc-adapter)]
     (clear spec)
-    (load! adapter store data)
-    (unload! adapter store data)
-    (= 0 (count (query (:spec store) ["select * from users"])))))
+    (load! adapter db data)
+    (unload! adapter db data)
+    (= 0 (count (query (:spec db) ["select * from users"])))))
 
 (deftest error-test
-  (load! (jdbc-adapter) store error-data)
-  (unload! (jdbc-adapter) store error-data))
+  (load! (jdbc-adapter) db error-data)
+  (unload! (jdbc-adapter) db error-data))


### PR DESCRIPTION
Duct components such as Ragtime require the datastore to be identified by `:db`, while this component requires `:store`. To reduce friction for integrating with Duct, I've updated this component from `:store` => `:db`. This is also in-line with more common clojure name conventions for databases.

I've tested the changes in a local Duct project, and was able to run both migrations (using Ragtime) and fixtures (using this component), so the renaming is working.

I tried running tests, but I got the following output:

```
Aug 25, 2015 10:55:03 PM clojure.tools.logging$eval1448$fn__1452 invoke
WARNING: Table "NON_EXISTENT_TABLE" not found; SQL statement:
INSERT INTO non_existent_table ( id ) VALUES ( ? ) [42102-170]
Aug 25, 2015 10:55:03 PM clojure.tools.logging$eval1448$fn__1452 invoke
WARNING: Table "NON_EXISTENT_TABLE" not found; SQL statement:
DELETE FROM non_existent_table [42102-170]

Ran 3 tests containing 0 assertions.
0 failures, 0 errors.
```

I checked out the base repository into a new directory, and ran the migrations and the tests, and received the same output, so I am not sure what is going on with the repository's tests, but both my changes and the base repository output the same (above).
