### PR TITLE
Fix stop through component and use insert-multi! when loading data

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
             "rollback" ["run" "-m" "user/rollback"]}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [com.stuartsierra/component "0.2.3"]
-                 [org.clojure/java.jdbc "0.4.1"]]
+                 [org.clojure/java.jdbc "0.6.1"]]
   :profiles {:dev {:source-paths ["dev"]
                    :repl-options {:init-ns user}
                    :resource-paths ["dev/resources"]   

--- a/src/fixtures/adapters/jdbc.clj
+++ b/src/fixtures/adapters/jdbc.clj
@@ -1,9 +1,9 @@
 (ns fixtures.adapters.jdbc
   (:require [fixtures.protocols :as protocols]
-            [clojure.java.jdbc :refer [insert! delete!]]))
+            [clojure.java.jdbc :refer [insert-multi! delete!]]))
 
 (defn- load-table! [spec table records]
-  (apply (partial insert! spec table) records))
+  (insert-multi! spec table records))
 
 (defn- clear-table! [spec table]
   (delete! spec table []))

--- a/src/fixtures/component.clj
+++ b/src/fixtures/component.clj
@@ -11,7 +11,7 @@
     (assoc component :loaded true))
 
   (stop [component]
-    (f/start (:db component) data {:adapter adapter :teardown teardown})
+    (f/stop (:db component) data {:adapter adapter :teardown teardown})
     (-> (assoc component :loaded false)
         (dissoc :setup :teardown :adapter :data))))
 


### PR DESCRIPTION
Recent versions of `clojure.java.jdbc` deprecate `insert!` when used with multiple rows and provide `insert-multi!` instead.

Also, there was a bug in component's stop implementation in which it still called `fixtures.core/start` instead of `fixtures.core/stop`.
